### PR TITLE
BUG: Fixed traceback due to missing import

### DIFF
--- a/SegmentEditorFloodFilling/SegmentEditorFloodFillingLib/SegmentEditorEffect.py
+++ b/SegmentEditorFloodFilling/SegmentEditorFloodFillingLib/SegmentEditorEffect.py
@@ -65,6 +65,7 @@ Click in the image to add voxels that have similar intensity to the clicked voxe
     
   def masterVolumeNodeChanged(self):
     # Set scalar range of master volume image data to threshold slider
+    import math
     import vtkSegmentationCorePython as vtkSegmentationCore
     masterImageData = self.scriptedEffect.masterVolumeImageData()
     if not masterImageData:
@@ -76,7 +77,6 @@ Click in the image to add voxels that have similar intensity to the clicked voxe
     # Intensity slider
     lo, hi = masterImageData.GetScalarRange()
     if (hi-lo > 0):
-      import math
       range = hi-lo
       stepSize = 1
       


### PR DESCRIPTION
This is a very minor bug fix. 

I was playing around with some effects and noticed a traceback error due to math not getting imported https://github.com/lassoan/SlicerSegmentEditorExtraEffects/blob/b6cdcaaf84e08df9af44abe67aef1598b7da4aeb/SegmentEditorFloodFilling/SegmentEditorFloodFillingLib/SegmentEditorEffect.py#L97

I've moved the math import to the beginning of `masterVolumeNodeChanged`.