### PR TITLE
ENH: Decrease preview slice intersection thickness for DrawTube effect

### DIFF
--- a/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
+++ b/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
@@ -377,7 +377,7 @@ class DrawTubeLogic(object):
       modelDisplayNode.SetColor(r, g, b)  # Edited segment color
       modelDisplayNode.BackfaceCullingOff()
       modelDisplayNode.SliceIntersectionVisibilityOn()
-      modelDisplayNode.SetSliceIntersectionThickness(4)
+      modelDisplayNode.SetSliceIntersectionThickness(2)
       modelDisplayNode.SetOpacity(0.3)  # Between 0-1, 1 being opaque
       slicer.mrmlScene.AddNode(modelDisplayNode)
       outputModel.SetAndObserveDisplayNodeID(modelDisplayNode.GetID())


### PR DESCRIPTION
Tubes are typically thin, and the preview with thickness of 4 obscured too much of the master volume.