### PR TITLE
BUG: Fix traceback changing segment model color when no display node

### DIFF
--- a/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
+++ b/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
@@ -208,10 +208,11 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
       if displayNode is None:
         logging.error("preview: Invalid segmentation display node!")
         color = [0.5, 0.5, 0.5]
-      segmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
-      r, g, b = segmentationNode.GetSegmentation().GetSegment(segmentID).GetColor()
-      if (r,g,b) != self.segmentModel.GetDisplayNode().GetColor():
-        self.segmentModel.GetDisplayNode().SetColor(r, g, b)  # Edited segment color
+      if self.segmentModel.GetDisplayNode():
+        segmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
+        r, g, b = segmentationNode.GetSegmentation().GetSegment(segmentID).GetColor()
+        if (r,g,b) != self.segmentModel.GetDisplayNode().GetColor():
+          self.segmentModel.GetDisplayNode().SetColor(r, g, b)  # Edited segment color
 
   def onCancel(self):
     self.reset()
@@ -337,9 +338,10 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
     segmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
     if segmentID and self.segmentModel:
-      r, g, b = segmentationNode.GetSegmentation().GetSegment(segmentID).GetColor()
-      if (r, g, b) != self.segmentModel.GetDisplayNode().GetColor():
-        self.segmentModel.GetDisplayNode().SetColor(r, g, b)  # Edited segment color
+      if self.segmentModel.GetDisplayNode():
+        r, g, b = segmentationNode.GetSegmentation().GetSegment(segmentID).GetColor()
+        if (r, g, b) != self.segmentModel.GetDisplayNode().GetColor():
+          self.segmentModel.GetDisplayNode().SetColor(r, g, b)  # Edited segment color
 
     self.updateGUIFromMRML()
 

--- a/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
+++ b/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
@@ -195,10 +195,11 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
       if displayNode is None:
         logging.error("preview: Invalid segmentation display node!")
         color = [0.5, 0.5, 0.5]
-      segmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
-      r, g, b = segmentationNode.GetSegmentation().GetSegment(segmentID).GetColor()
-      if (r,g,b) != self.segmentModel.GetDisplayNode().GetColor():
-        self.segmentModel.GetDisplayNode().SetColor(r, g, b)  # Edited segment color
+      if self.segmentModel.GetDisplayNode():
+        segmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
+        r, g, b = segmentationNode.GetSegmentation().GetSegment(segmentID).GetColor()
+        if (r,g,b) != self.segmentModel.GetDisplayNode().GetColor():
+          self.segmentModel.GetDisplayNode().SetColor(r, g, b)  # Edited segment color
 
   def onCancel(self):
     self.reset()
@@ -325,9 +326,10 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
     segmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
     if segmentID and self.segmentModel:
-      r, g, b = segmentationNode.GetSegmentation().GetSegment(segmentID).GetColor()
-      if (r, g, b) != self.segmentModel.GetDisplayNode().GetColor():
-        self.segmentModel.GetDisplayNode().SetColor(r, g, b)  # Edited segment color
+      if self.segmentModel.GetDisplayNode():
+        r, g, b = segmentationNode.GetSegmentation().GetSegment(segmentID).GetColor()
+        if (r, g, b) != self.segmentModel.GetDisplayNode().GetColor():
+          self.segmentModel.GetDisplayNode().SetColor(r, g, b)  # Edited segment color
 
     self.updateGUIFromMRML()
 


### PR DESCRIPTION
If you add a segment, go into either "Draw tube" or "Surface cut" effect and toggle fiducial placement mode on and then add another segment, you get the following tracebacks below because the segmentModel doesn't have a display node.
```powershell
Traceback (most recent call last):
  File "C:/Users/james/AppData/Roaming/NA-MIC/Extensions-27931/SegmentEditorExtraEffects/lib/Slicer-4.10/qt-scripted-modules/SegmentEditorDrawTubeLib/SegmentEditorEffect.py", line 213, in onSegmentModified
    if (r,g,b) != self.segmentModel.GetDisplayNode().GetColor():
AttributeError: 'NoneType' object has no attribute 'GetColor'
Traceback (most recent call last):
  File "C:/Users/james/AppData/Roaming/NA-MIC/Extensions-27931/SegmentEditorExtraEffects/lib/Slicer-4.10/qt-scripted-modules/SegmentEditorDrawTubeLib/SegmentEditorEffect.py", line 341, in onSegmentEditorNodeModified
    if (r, g, b) != self.segmentModel.GetDisplayNode().GetColor():
AttributeError: 'NoneType' object has no attribute 'GetColor'
```