### PR TITLE
BUG: Fix memory leaks due to factory method

### DIFF
--- a/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
+++ b/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
@@ -369,7 +369,7 @@ class DrawTubeLogic(object):
 
     # Create default model display node if does not exist yet
     if not outputModel.GetDisplayNode():
-      modelDisplayNode = slicer.mrmlScene.CreateNodeByClass("vtkMRMLModelDisplayNode")
+      modelDisplayNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelDisplayNode")
 
       # Get color of edited segment
       segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
@@ -381,7 +381,6 @@ class DrawTubeLogic(object):
       modelDisplayNode.SliceIntersectionVisibilityOn()
       modelDisplayNode.SetSliceIntersectionThickness(2)
       modelDisplayNode.SetOpacity(0.3)  # Between 0-1, 1 being opaque
-      slicer.mrmlScene.AddNode(modelDisplayNode)
       outputModel.SetAndObserveDisplayNodeID(modelDisplayNode.GetID())
 
       outputModel.GetDisplayNode().SliceIntersectionVisibilityOn()

--- a/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
+++ b/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
@@ -354,7 +354,7 @@ class SurfaceCutLogic(object):
 
     # Create default model display node if does not exist yet
     if not outputModel.GetDisplayNode():
-      modelDisplayNode = slicer.mrmlScene.CreateNodeByClass("vtkMRMLModelDisplayNode")
+      modelDisplayNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLModelDisplayNode")
 
       # Get color of edited segment
       segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
@@ -366,7 +366,6 @@ class SurfaceCutLogic(object):
       modelDisplayNode.SliceIntersectionVisibilityOn()
       modelDisplayNode.SetSliceIntersectionThickness(4)
       modelDisplayNode.SetOpacity(0.3)  # Between 0-1, 1 being opaque
-      slicer.mrmlScene.AddNode(modelDisplayNode)
       outputModel.SetAndObserveDisplayNodeID(modelDisplayNode.GetID())
 
       outputModel.GetDisplayNode().SliceIntersectionVisibilityOn()


### PR DESCRIPTION
This fixes memory leaks which occurred after placing a fiducial point when using either the "Surface cut" or "Draw tube" effect and then closing Slicer.

Per [MemoryManagement#Python_scripts_and_scripted_modules](https://www.slicer.org/wiki/Documentation/Nightly/Developers/Tutorials/MemoryManagement#Python_scripts_and_scripted_modules) on the Slicer wiki, 

> to avoid forgetting the UnRegister call, it is better to avoid factory methods whenever it is possible.

I've gone with the recommended `AddNewNodeByClass` method instead of the factory `CreateNodeByClass` method.

The following leaks are fixed by this PR:
```powershell
vtkDebugLeaks has detected LEAKS!
Class "vtkCellData" has 2 instances still around.
Class "vtkInformationVector" has 21 instances still around.
Class "vtkPointData" has 2 instances still around.
Class "vtkGeometryFilter" has 1 instance still around.
Class "vtkCompositeDataPipeline" has 4 instances still around.
Class "vtkObservation" has 1 instance still around.
Class "vtkTrivialProducer" has 1 instance still around.
Class "class vtkBuffer<__int64>" has 4 instances still around.
Class "vtkPassThrough" has 1 instance still around.
Class "vtkObserverManager" has 1 instance still around.
Class "vtkIntArray" has 1 instance still around.
Class "vtkPoints" has 1 instance still around.
Class "vtkInformation" has 54 instances still around.
Class "vtkEventBroker" has 1 instance still around.
Class "vtkPolyData" has 2 instances still around.
Class "class vtkBuffer<int>" has 1 instance still around.
Class "vtkAlgorithmOutput" has 4 instances still around.
Class "vtkInformationIntegerValue" has 74 instances still around.
Class "vtkCellArray" has 4 instances still around.
Class "class vtkBuffer<float>" has 3 instances still around.
Class "vtkFloatArray" has 3 instances still around.
Class "vtkInformationStringValue" has 2 instances still around.
Class "vtkInformationExecutivePortVectorValue" has 4 instances still around.
Class "vtkIdTypeArray" has 4 instances still around.
Class "vtkInformationIterator" has 5 instances still around.
Class "vtkMRMLModelDisplayNode" has 1 instance still around.
Class "vtkFieldData" has 2 instances still around.
Class "vtkAssignAttribute" has 1 instance still around.
Class "vtkInformationDoubleVectorValue" has 3 instances still around.
Class "vtkStreamingDemandDrivenPipeline" has 1 instance still around.
Class "vtkTimerLog" has 1 instance still around.
Class "vtkThreshold" has 1 instance still around.
Class "vtkCommand or subclass" has 6 instances still around.
Class "vtkInformationExecutivePortValue" has 4 instances still around.
```