### PR TITLE
BUG: Fix old reference to vtkCurveGenerator in MarkupsToModel

### DIFF
--- a/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
+++ b/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
@@ -359,8 +359,7 @@ class DrawTubeLogic(object):
   def __init__(self, scriptedEffect):
     self.scriptedEffect = scriptedEffect
     self.radius = 1.0
-    import vtkSlicerMarkupsToModelModuleLogicPython
-    self.curveGenerator = vtkSlicerMarkupsToModelModuleLogicPython.vtkCurveGenerator()
+    self.curveGenerator = slicer.vtkCurveGenerator()
 
   def updateModelFromMarkup(self, inputMarkup, outputModel):
     """


### PR DESCRIPTION
This closes #16 and works for both the latest stable (Slicer 4.10.1) and the current Slicer nightly.