### PR TITLE
COMP: Fix failing build due to missing file

### DIFF
--- a/SegmentEditorSplitVolume/SegmentEditorSplitVolumeLib/__init__.py
+++ b/SegmentEditorSplitVolume/SegmentEditorSplitVolumeLib/__init__.py
@@ -1,0 +1,4 @@
+from SegmentEditorEffects.AbstractScriptedSegmentEditorEffect import *
+from SegmentEditorEffects.AbstractScriptedSegmentEditorLabelEffect import *
+
+from SegmentEditorEffect import *


### PR DESCRIPTION
This fixes the [failed configuring](http://slicer.cdash.org/viewConfigure.php?buildid=1609073) of the extension.
```log
CMake Error at /work/Stable/Slicer-4102/CMake/SlicerMacroBuildScriptedModule.cmake:78 (message):
  slicerMacroBuildScriptedModule(SCRIPTS) given nonexistent file or directory
  'SegmentEditorSplitVolumeLib/__init__.py'
Call Stack (most recent call first):
  SegmentEditorSplitVolume/CMakeLists.txt:17 (slicerMacroBuildScriptedModule)


-- Configuring incomplete, errors occurred!
```