### PR TITLE
ENH: Allow fast marching to work with merged labelmaps

### DIFF
--- a/SegmentEditorFastMarching/SegmentEditorFastMarchingLib/SegmentEditorEffect.py
+++ b/SegmentEditorFastMarching/SegmentEditorFastMarchingLib/SegmentEditorEffect.py
@@ -144,6 +144,10 @@ The effect uses <a href="http://www.spl.harvard.edu/publications/item/view/193">
       masterImageDataShort.CopyDirections(masterImageData) # Copy geometry
       masterImageData = masterImageDataShort
 
+    if not self.originalSelectedSegmentLabelmap:
+      segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
+      segmentationNode.GetSegmentation().SeparateSegmentLabelmap(self.scriptedEffect.parameterSetNode().GetSelectedSegmentID())
+
     selectedSegmentLabelmap = self.scriptedEffect.selectedSegmentLabelmap()
     
     if not self.originalSelectedSegmentLabelmap:
@@ -264,7 +268,8 @@ The effect uses <a href="http://www.spl.harvard.edu/publications/item/view/193">
     # Apply changes
     import vtkSegmentationCorePython as vtkSegmentationCore
     segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
-    modifierLabelmap = segmentationNode.GetBinaryLabelmapRepresentation(self.selectedSegmentId)
+    modifierLabelmap = vtkSegmentationCore.vtkOrientedImageData()
+    segmentationNode.GetBinaryLabelmapRepresentation(self.selectedSegmentId, modifierLabelmap)
     self.scriptedEffect.modifySelectedSegmentByLabelmap(modifierLabelmap, slicer.qSlicerSegmentEditorAbstractEffect.ModificationModeSet)
     self.originalSelectedSegmentLabelmap = None
 


### PR DESCRIPTION
Before starting the fast marching algorithm, the selected segment is moved to a separate layer.
This ensures that the preview for the segment does not interfere with the other merged segments in the labelmap.

At some point, it may be worth changing the fast marching effect to be an AbstractScriptedSegmentEditorAutoCompleteEffect, so that only the preview would be modified.

To be merged when https://github.com/Slicer/Slicer/pull/1221 is integrated.