### PR TITLE
Prevent segment editor error messages on scene close

### DIFF
--- a/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
+++ b/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
@@ -166,6 +166,9 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     self.scriptedEffect.setParameterDefault("NumberOfLineSegmentsBetweenControlPoints", 15)
 
   def updateGUIFromMRML(self):
+    if slicer.mrmlScene.IsClosing():
+      return
+
     if self.segmentMarkupNode:
       self.cancelButton.setEnabled(self.getNumberOfDefinedControlPoints() is not 0)
       self.applyButton.setEnabled(self.getNumberOfDefinedControlPoints() >= 2)
@@ -272,11 +275,13 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
       self.editButton.setEnabled(True)
 
     if self.segmentModel:
-      slicer.mrmlScene.RemoveNode(self.segmentModel)
+      if self.segmentModel.GetScene():
+        slicer.mrmlScene.RemoveNode(self.segmentModel)
       self.segmentModel = None
 
     if self.segmentMarkupNode:
-      slicer.mrmlScene.RemoveNode(self.segmentMarkupNode)
+      if self.segmentMarkupNode.GetScene():
+        slicer.mrmlScene.RemoveNode(self.segmentMarkupNode)
       self.setAndObserveSegmentMarkupNode(None)
 
   def onApply(self):
@@ -383,6 +388,9 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
                                                                           self.onSegmentEditorNodeModified)
 
   def onSegmentEditorNodeModified(self, observer, eventid):
+    if self.scriptedEffect.parameterSetNode() is None:
+      return
+
     # Get color of edited segment
     segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
     segmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()


### PR DESCRIPTION
Fixes 2 types of errors:
- Segment editor modified events were causing widget updates while the scene was closing. Fixed by adding a check to see if the scene is being closed
- Subject hierarchy errors from trying to remove a node that was not in the scene. Fixed by checking if the node has a scene before trying to remove it.