### PR TITLE
BUG: Fix traceback when there is no segment for segmentID defined

### DIFF
--- a/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
+++ b/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
@@ -177,7 +177,8 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
     if segmentID and segmentationNode:
       segment = segmentationNode.GetSegmentation().GetSegment(segmentID)
-      self.editButton.setVisible(segment.HasTag("DrawTubeEffectMarkupPositions"))
+      if segment:
+        self.editButton.setVisible(segment.HasTag("DrawTubeEffectMarkupPositions"))
 
     interpolationName = self.scriptedEffect.parameter("Interpolation")
     interpolationButton = list(self.buttonToInterpolationTypeMap.keys())[list(self.buttonToInterpolationTypeMap.values()).index(interpolationName)]
@@ -230,12 +231,14 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
       displayNode = segmentationNode.GetDisplayNode()
       if displayNode is None:
         logging.error("preview: Invalid segmentation display node!")
-        color = [0.5, 0.5, 0.5]
       if self.segmentModel.GetDisplayNode():
         segmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
-        r, g, b = segmentationNode.GetSegmentation().GetSegment(segmentID).GetColor()
-        if (r,g,b) != self.segmentModel.GetDisplayNode().GetColor():
-          self.segmentModel.GetDisplayNode().SetColor(r, g, b)  # Edited segment color
+        if segmentID:
+          segment = segmentationNode.GetSegmentation().GetSegment(segmentID)
+          if segment:
+            r, g, b = segment.GetColor()
+            if (r,g,b) != self.segmentModel.GetDisplayNode().GetColor():
+              self.segmentModel.GetDisplayNode().SetColor(r, g, b)  # Edited segment color
 
   def onCancel(self):
     self.reset()

--- a/SegmentEditorEngrave/SegmentEditorEngraveLib/SegmentEditorEffect.py
+++ b/SegmentEditorEngrave/SegmentEditorEngraveLib/SegmentEditorEffect.py
@@ -175,7 +175,8 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
     if segmentID and segmentationNode:
       segment = segmentationNode.GetSegmentation().GetSegment(segmentID)
-      self.editButton.setVisible(segment.HasTag("EngraveEffectMarkupPositions"))
+      if segment:
+        self.editButton.setVisible(segment.HasTag("EngraveEffectMarkupPositions"))
 
     modeName = self.scriptedEffect.parameter("Mode")
     modeButton = list(self.buttonToModeTypeMap.keys())[list(self.buttonToModeTypeMap.values()).index(modeName)]

--- a/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
+++ b/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
@@ -167,7 +167,8 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
     if segmentID and segmentationNode:
       segment = segmentationNode.GetSegmentation().GetSegment(segmentID)
-      self.editButton.setVisible(segment.HasTag("SurfaceCutEffectMarkupPositions"))
+      if segment:
+        self.editButton.setVisible(segment.HasTag("SurfaceCutEffectMarkupPositions"))
 
     operationName = self.scriptedEffect.parameter("Operation")
     if operationName != "":
@@ -221,9 +222,12 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
         color = [0.5, 0.5, 0.5]
       if self.segmentModel.GetDisplayNode():
         segmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
-        r, g, b = segmentationNode.GetSegmentation().GetSegment(segmentID).GetColor()
-        if (r,g,b) != self.segmentModel.GetDisplayNode().GetColor():
-          self.segmentModel.GetDisplayNode().SetColor(r, g, b)  # Edited segment color
+        if segmentID:
+          segment = segmentationNode.GetSegmentation().GetSegment(segmentID)
+          if segment:
+            r, g, b = segment.GetColor()
+            if (r,g,b) != self.segmentModel.GetDisplayNode().GetColor():
+              self.segmentModel.GetDisplayNode().SetColor(r, g, b)  # Edited segment color
 
   def onCancel(self):
     self.reset()


### PR DESCRIPTION
I was running into some tracebacks such as the one below when working with a segmentation node synchronized with a volume sequence where it was to only be displayed at one specific sequence index.

This just doesn't attempt to modify the editButton visible state if there isn't a segment with the specified segmentID in the segmentation node.  Also updated some other places with similar code to DrawTube such as SurfaceCut.
```
Traceback (most recent call last):
  File "C:/Users/james/AppData/Roaming/NA-MIC/Extensions-29368/SegmentEditorExtraEffects/lib/Slicer-4.11/qt-scripted-modules/SegmentEditorDrawTubeLib/SegmentEditorEffect.py", line 225, in onSegmentModified
    self.updateGUIFromMRML()
  File "C:/Users/james/AppData/Roaming/NA-MIC/Extensions-29368/SegmentEditorExtraEffects/lib/Slicer-4.11/qt-scripted-modules/SegmentEditorDrawTubeLib/SegmentEditorEffect.py", line 180, in updateGUIFromMRML
    self.editButton.setVisible(segment.HasTag("DrawTubeEffectMarkupPositions"))
AttributeError: 'NoneType' object has no attribute 'HasTag'
```

cc: @lassoan 