### PR TITLE
BUG: Fix traceback due to incorrect number of input arguments

### DIFF
--- a/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
+++ b/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
@@ -264,7 +264,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
 
     fPosStr = vtk.mutable("")
     segment.GetTag("DrawTubeEffectMarkupPositions", fPosStr)
-    self.logic.setPointsFromString(self, self.segmentMarkupNode, fPosStr)
+    self.logic.setPointsFromString(self.segmentMarkupNode, fPosStr)
 
     self.editButton.setEnabled(False)
     self.updateModelFromSegmentMarkupNode()

--- a/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
+++ b/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
@@ -254,7 +254,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
 
     fPosStr = vtk.mutable("")
     segment.GetTag("SurfaceCutEffectMarkupPositions", fPosStr)
-    self.logic.setPointsFromString(self, self.segmentMarkupNode, fPosStr)
+    self.logic.setPointsFromString(self.segmentMarkupNode, fPosStr)
 
     self.editButton.setEnabled(False)
     self.updateModelFromSegmentMarkupNode()


### PR DESCRIPTION
@lassoan I observed this traceback while using Surface Cut.

Introduced by https://github.com/lassoan/SlicerSegmentEditorExtraEffects/commit/bb09b8e0176ecd5a698f9bf1345be89e9c926f2d