### PR TITLE
Allow vtkMRMLMarkupsROINode to be used as segmentation extent limit.

### DIFF
--- a/SegmentEditorFloodFilling/SegmentEditorFloodFillingLib/SegmentEditorEffect.py
+++ b/SegmentEditorFloodFilling/SegmentEditorFloodFillingLib/SegmentEditorEffect.py
@@ -64,7 +64,7 @@ Masking settings can be used to restrict growing to a specific region.
 
     # Add ROI options
     self.roiSelector = slicer.qMRMLNodeComboBox()
-    self.roiSelector.nodeTypes = ['vtkMRMLAnnotationROINode']
+    self.roiSelector.nodeTypes = ['vtkMRMLMarkupsROINode', 'vtkMRMLAnnotationROINode']
     self.roiSelector.noneEnabled = True
     self.roiSelector.setMRMLScene(slicer.mrmlScene)
     self.scriptedEffect.addLabeledOptionsWidget("ROI: ", self.roiSelector)

--- a/SegmentEditorLocalThreshold/SegmentEditorLocalThresholdLib/SegmentEditorEffect.py
+++ b/SegmentEditorLocalThreshold/SegmentEditorLocalThresholdLib/SegmentEditorEffect.py
@@ -162,7 +162,7 @@ Fill segment in a selected region based on master volume intensity range<br>.
 
     # Add ROI options
     self.roiSelector = slicer.qMRMLNodeComboBox()
-    self.roiSelector.nodeTypes = ['vtkMRMLAnnotationROINode']
+    self.roiSelector.nodeTypes = ['vtkMRMLMarkupsROINode', 'vtkMRMLAnnotationROINode']
     self.roiSelector.noneEnabled = True
     self.roiSelector.setMRMLScene(slicer.mrmlScene)
     self.scriptedEffect.addLabeledOptionsWidget("ROI: ", self.roiSelector)


### PR DESCRIPTION
Since vtkMRMLAnnotationROINode is being relegated to legacy, add
vtkMRMLMarkupsROINode as usable node types in 'Local threshold' and
'Flood filling' effects.

Please consider this trivial patch. No issue was found with simple testing.

Thank you.
