### PR TITLE
STYLE: Upgrade python syntax to 3.6 and newer

### DIFF
--- a/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
+++ b/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
@@ -176,7 +176,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
       return
 
     if self.segmentMarkupNode:
-      self.cancelButton.setEnabled(self.getNumberOfDefinedControlPoints() is not 0)
+      self.cancelButton.setEnabled(self.getNumberOfDefinedControlPoints() != 0)
       self.applyButton.setEnabled(self.getNumberOfDefinedControlPoints() >= 2)
 
     segmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
@@ -222,7 +222,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     self.updateModelFromSegmentMarkupNode()
 
   def onSegmentModified(self, caller, event):
-    if not self.editButton.isEnabled() and self.segmentMarkupNode.GetNumberOfFiducials() is not 0:
+    if not self.editButton.isEnabled() and self.segmentMarkupNode.GetNumberOfFiducials() != 0:
       self.reset()
       # Create model node prior to markup node for display order
       self.createNewModelNode()
@@ -440,7 +440,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
         count = self.segmentMarkupNode.GetNumberOfFiducials()
     return count
 
-class DrawTubeLogic(object):
+class DrawTubeLogic:
 
   def __init__(self, scriptedEffect):
     self.scriptedEffect = scriptedEffect
@@ -519,14 +519,14 @@ class DrawTubeLogic(object):
     import vtkSegmentationCore
 
     if not segmentMarkupNode:
-      raise AttributeError("{}: segment markup node not set.".format(self.__class__.__name__))
+      raise AttributeError(f"{self.__class__.__name__}: segment markup node not set.")
     if not segmentModel:
-      raise AttributeError("{}: segment model not set.".format(self.__class__.__name__))
+      raise AttributeError(f"{self.__class__.__name__}: segment model not set.")
 
     if segmentMarkupNode and segmentModel.GetPolyData().GetNumberOfCells() > 0:
       segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
       if not segmentationNode:
-        raise AttributeError("{}: Segmentation node not set.".format(self.__class__.__name__))
+        raise AttributeError(f"{self.__class__.__name__}: Segmentation node not set.")
 
       modifierLabelmap = self.scriptedEffect.defaultModifierLabelmap()
       if not modifierLabelmap:

--- a/SegmentEditorEngrave/SegmentEditorEngraveLib/SegmentEditorEffect.py
+++ b/SegmentEditorEngrave/SegmentEditorEngraveLib/SegmentEditorEffect.py
@@ -168,7 +168,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
       return
 
     if self.segmentMarkupNode:
-      self.cancelButton.setEnabled(self.getNumberOfDefinedControlPoints() is not 0)
+      self.cancelButton.setEnabled(self.getNumberOfDefinedControlPoints() != 0)
       self.applyButton.setEnabled(self.getNumberOfDefinedControlPoints() >= 3)
       # Prevent placing additional planes
       self.markupsPlacementToggle.placeButton().setVisible(self.getNumberOfDefinedControlPoints() < 3)
@@ -231,7 +231,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     self.updateModelFromSegmentMarkupNode()
 
   def onSegmentModified(self, caller, event):
-    if not self.editButton.isEnabled() and self.segmentMarkupNode.GetNumberOfControlPoints() is not 0:
+    if not self.editButton.isEnabled() and self.segmentMarkupNode.GetNumberOfControlPoints() != 0:
       self.reset()
       # Create model node prior to markup node for display order
       self.createNewModelNode()
@@ -430,7 +430,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
       return 0
     return self.segmentMarkupNode.GetNumberOfDefinedControlPoints()
 
-class EngraveLogic(object):
+class EngraveLogic:
 
   def __init__(self, scriptedEffect):
     self.scriptedEffect = scriptedEffect
@@ -512,14 +512,14 @@ class EngraveLogic(object):
     import vtkSegmentationCore
 
     if not segmentMarkupNode:
-      raise AttributeError("{}: segment markup node not set.".format(self.__class__.__name__))
+      raise AttributeError(f"{self.__class__.__name__}: segment markup node not set.")
     if not segmentModel:
-      raise AttributeError("{}: segment model not set.".format(self.__class__.__name__))
+      raise AttributeError(f"{self.__class__.__name__}: segment model not set.")
 
     if segmentMarkupNode and segmentModel.GetPolyData().GetNumberOfCells() > 0:
       segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
       if not segmentationNode:
-        raise AttributeError("{}: Segmentation node not set.".format(self.__class__.__name__))
+        raise AttributeError(f"{self.__class__.__name__}: Segmentation node not set.")
 
       modifierLabelmap = self.scriptedEffect.defaultModifierLabelmap()
       if not modifierLabelmap:

--- a/SegmentEditorHollow/SegmentEditorHollowLib/SegmentEditorEffect.py
+++ b/SegmentEditorHollow/SegmentEditorHollowLib/SegmentEditorEffect.py
@@ -140,7 +140,7 @@ by replacing the segment with a uniform-thickness shell defined by the segment b
       self.kernelSizePixel.text = "too thin"
       self.applyButton.setEnabled(False)
     else:
-      self.kernelSizePixel.text = "{0}x{1}x{2} pixels".format(abs(kernelSizePixel[0]), abs(kernelSizePixel[1]), abs(kernelSizePixel[2]))
+      self.kernelSizePixel.text = f"{abs(kernelSizePixel[0])}x{abs(kernelSizePixel[1])}x{abs(kernelSizePixel[2])} pixels"
       self.applyButton.setEnabled(True)
 
     selectedSegmentLabelmap = self.scriptedEffect.selectedSegmentLabelmap()

--- a/SegmentEditorLocalThreshold/SegmentEditorLocalThresholdLib/SegmentEditorEffect.py
+++ b/SegmentEditorLocalThreshold/SegmentEditorLocalThresholdLib/SegmentEditorEffect.py
@@ -208,7 +208,7 @@ Fill segment in a selected region based on master volume intensity range<br>.
       self.kernelSizePixel.text = "feature too small"
       self.applyButton.setEnabled(False)
     else:
-      self.kernelSizePixel.text = "{0}x{1}x{2} pixels".format(abs(kernelSizePixel[0]), abs(kernelSizePixel[1]), abs(kernelSizePixel[2]))
+      self.kernelSizePixel.text = f"{abs(kernelSizePixel[0])}x{abs(kernelSizePixel[1])}x{abs(kernelSizePixel[2])} pixels"
       self.applyButton.setEnabled(True)
 
 

--- a/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
+++ b/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
@@ -167,7 +167,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
       return
 
     if self.segmentMarkupNode:
-      self.cancelButton.setEnabled(self.getNumberOfDefinedControlPoints() is not 0)
+      self.cancelButton.setEnabled(self.getNumberOfDefinedControlPoints() != 0)
       self.applyButton.setEnabled(self.getNumberOfDefinedControlPoints() >= 3)
 
     segmentID = self.scriptedEffect.parameterSetNode().GetSelectedSegmentID()
@@ -211,7 +211,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
         self.fiducialPlacementToggle.setCurrentNode(self.segmentMarkupNode)
 
   def onSegmentModified(self, caller, event):
-    if not self.editButton.isEnabled() and self.segmentMarkupNode.GetNumberOfFiducials() is not 0:
+    if not self.editButton.isEnabled() and self.segmentMarkupNode.GetNumberOfFiducials() != 0:
       self.reset()
       # Create model node prior to markup node for display order
       self.createNewModelNode()
@@ -431,7 +431,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
         count = self.segmentMarkupNode.GetNumberOfFiducials()
     return count
 
-class SurfaceCutLogic(object):
+class SurfaceCutLogic:
 
   def __init__(self, scriptedEffect):
     self.scriptedEffect = scriptedEffect
@@ -496,16 +496,16 @@ class SurfaceCutLogic(object):
     import vtkSegmentationCorePython as vtkSegmentationCore
 
     if not segmentMarkupNode:
-      raise AttributeError("{}: segment markup node not set.".format(self.__class__.__name__))
+      raise AttributeError(f"{self.__class__.__name__}: segment markup node not set.")
     if not segmentModel:
-      raise AttributeError("{}: segment model not set.".format(self.__class__.__name__))
+      raise AttributeError(f"{self.__class__.__name__}: segment model not set.")
 
     if segmentMarkupNode and segmentModel.GetPolyData().GetNumberOfPolys() > 0:
       operationName = self.scriptedEffect.parameter("Operation")
 
       segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
       if not segmentationNode:
-        raise AttributeError("{}: Segmentation node not set.".format(self.__class__.__name__))
+        raise AttributeError(f"{self.__class__.__name__}: Segmentation node not set.")
 
       modifierLabelmap = self.scriptedEffect.defaultModifierLabelmap()
       if not modifierLabelmap:


### PR DESCRIPTION
Some syntax upgrading is neccessary for SlicerSegmentEditorExtraEffects as I noticed in https://slicer.cdash.org/viewBuildError.php?buildid=2569128 that there were syntax warnings. These warnings are present because Slicer recently upgrade from Python 3.6.7 to Python 3.9.10 in https://github.com/Slicer/Slicer/commit/34e48e8aef5dad19ec8a955d6f48a1940846e3f3.

The syntax warning in question started as of Python 3.8.
https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

> The compiler now produces a [SyntaxWarning](https://docs.python.org/3.8/library/exceptions.html#SyntaxWarning) when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in [bpo-34850](https://bugs.python.org/issue34850).)

This PR uses [`pyupgrade`](https://github.com/asottile/pyupgrade) to automatically upgrade python syntax to newer versions. The script listed below was run for Python 3.6+ syntax with changes committed, followed by Python 3.7+, then Python 3.8+ and finally Python 3.9+.  There were no changes made when specifying Python 3.7+, 3.8+, or 3.9+ which is why there are no commits for those iterations.

## Using pyupgrade

- Install: `PythonSlicer -m pip install pyupgrade`
- Running:
  - On 1 file: `PythonSlicer -m pyupgrade --py36-plus MyPythonFile.py`
  - On multiple files: Here is my pyupgrade-script.py written to automate running pyupgrade across all python files in the SlicerSegmentEditorExtraEffects repo. It was run by `PythonSlicer pyupgrade-script.py`.
```python
# pyupgrade-script.py
import os
import subprocess

search_directory = "C:/Users/JamesButler/Documents/GitHub/SlicerSegmentEditorExtraEffects"
for root, _, files in os.walk(search_directory):
    for file_item in files:
        file_path = os.path.join(root, file_item)
        if os.path.isfile(file_path) and file_path.endswith(".py"):
            subprocess.call(["PythonSlicer", "-m", "pyupgrade", "--py36-plus", file_path])
```
