### PR TITLE
ENH: Use non-deprecated Markups API

### DIFF
--- a/SegmentEditorDrawTube/SegmentEditorDrawTube.py
+++ b/SegmentEditorDrawTube/SegmentEditorDrawTube.py
@@ -117,7 +117,7 @@ class SegmentEditorDrawTubeTest(ScriptedLoadableModuleTest):
              [-17.163865662527982, 33.7411348180564, 17.500000000000007], [-14.200893276341674, 21.889245273311168, 17.500000000000007]]
 
     for p in points:
-      effect.self().segmentMarkupNode.AddFiducialFromArray(p)
+      effect.self().segmentMarkupNode.AddControlPoint(p)
 
     effect.self().onApply()
 

--- a/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
+++ b/SegmentEditorDrawTube/SegmentEditorDrawTubeLib/SegmentEditorEffect.py
@@ -222,7 +222,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     self.updateModelFromSegmentMarkupNode()
 
   def onSegmentModified(self, caller, event):
-    if not self.editButton.isEnabled() and self.segmentMarkupNode.GetNumberOfFiducials() != 0:
+    if not self.editButton.isEnabled() and self.segmentMarkupNode.GetNumberOfControlPoints() != 0:
       self.reset()
       # Create model node prior to markup node for display order
       self.createNewModelNode()
@@ -437,7 +437,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
       if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
         count = self.segmentMarkupNode.GetNumberOfDefinedControlPoints()
       else:
-        count = self.segmentMarkupNode.GetNumberOfFiducials()
+        count = self.segmentMarkupNode.GetNumberOfControlPoints()
     return count
 
 class DrawTubeLogic:
@@ -500,17 +500,16 @@ class DrawTubeLogic:
     wasModified = segmentMarkupNode.StartModify()
     segmentMarkupNode.RemoveAllControlPoints()
     for i in range(fPosNum):
-      segmentMarkupNode.AddFiducialFromArray(fPos[i])
+      segmentMarkupNode.AddControlPoint(fPos[i])
     segmentMarkupNode.EndModify(wasModified)
 
   def getPointsAsString(self, segmentMarkupNode):
     # get fiducial positions as space-separated list
     import numpy
-    n = segmentMarkupNode.GetNumberOfFiducials()
+    n = segmentMarkupNode.GetNumberOfControlPoints()
     fPos = []
     for i in range(n):
-      coord = [0.0, 0.0, 0.0]
-      segmentMarkupNode.GetNthFiducialPosition(i, coord)
+      coord = segmentMarkupNode.GetNthControlPointPosition(i)
       fPos.extend(coord)
     fPosString = ' '.join(map(str, fPos))
     return fPosString

--- a/SegmentEditorEngrave/SegmentEditorEngrave.py
+++ b/SegmentEditorEngrave/SegmentEditorEngrave.py
@@ -117,7 +117,7 @@ class SegmentEditorEngraveTest(ScriptedLoadableModuleTest):
     #          [-17.163865662527982, 33.7411348180564, 17.500000000000007], [-14.200893276341674, 21.889245273311168, 17.500000000000007]]
 
     # for p in points:
-    #   effect.self().segmentMarkupNode.AddFiducialFromArray(p)
+    #   effect.self().segmentMarkupNode.AddControlPoint(p)
 
     # effect.self().onApply()
 

--- a/SegmentEditorEngrave/SegmentEditorEngraveLib/SegmentEditorEffect.py
+++ b/SegmentEditorEngrave/SegmentEditorEngraveLib/SegmentEditorEffect.py
@@ -76,7 +76,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     self.textHeightSlider.value = 10
     self.textHeightSlider.singleStep = 0.1
     self.textHeightSlider.pageStep = 1.0
-    self.textHeightLabel = self.scriptedEffect.addLabeledOptionsWidget("Text height:", self.textHeightSlider) 
+    self.textHeightLabel = self.scriptedEffect.addLabeledOptionsWidget("Text height:", self.textHeightSlider)
 
     # Text height slider
     self.textDepthSlider = ctk.ctkSliderWidget()
@@ -86,7 +86,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     self.textDepthSlider.value = 5
     self.textDepthSlider.singleStep = 0.1
     self.textDepthSlider.pageStep = 1.0
-    self.textDepthLabel = self.scriptedEffect.addLabeledOptionsWidget("Depth:", self.textDepthSlider) 
+    self.textDepthLabel = self.scriptedEffect.addLabeledOptionsWidget("Depth:", self.textDepthSlider)
 
     # Mode buttons
     self.engraveButton = qt.QRadioButton("Engrave")
@@ -161,7 +161,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     self.scriptedEffect.setParameterDefault("Text", "Text")
     self.scriptedEffect.setParameterDefault("Mode", "ENGRAVE")
     self.scriptedEffect.setParameterDefault("TextDepth", 5.0)
-    self.scriptedEffect.setParameterDefault("TextHeight", 10.0) 
+    self.scriptedEffect.setParameterDefault("TextHeight", 10.0)
 
   def updateGUIFromMRML(self):
     if slicer.mrmlScene.IsClosing():
@@ -298,7 +298,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
     # This can be a long operation - indicate it to the user
     qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
     self.observeSegmentation(False)
-    self.logic.apply(self.segmentMarkupNode, self.segmentModel, 
+    self.logic.apply(self.segmentMarkupNode, self.segmentModel,
       self.scriptedEffect.parameter("Text"),
       self.scriptedEffect.doubleParameter("TextDepth"),
       self.scriptedEffect.doubleParameter("TextHeight"),
@@ -595,8 +595,7 @@ class EngraveLogic:
       n = segmentMarkupNode.GetNumberOfControlPoints()
       fPos = []
       for i in range(n):
-        coord = [0.0, 0.0, 0.0]
-        segmentMarkupNode.GetNthControlPointPosition(i, coord)
+        coord = segmentMarkupNode.GetNthControlPointPosition(i)
         fPos.extend(coord)
       fPosString = ' '.join(map(str, fPos))
 

--- a/SegmentEditorSurfaceCut/SegmentEditorSurfaceCut.py
+++ b/SegmentEditorSurfaceCut/SegmentEditorSurfaceCut.py
@@ -118,7 +118,7 @@ class SegmentEditorSurfaceCutTest(ScriptedLoadableModuleTest):
              [-17.163865662527982, 33.7411348180564, 17.500000000000007], [-14.200893276341674, 21.889245273311168, 17.500000000000007]]
 
     for p in points:
-      effect.self().segmentMarkupNode.AddFiducialFromArray(p)
+      effect.self().segmentMarkupNode.AddControlPoint(p)
 
     effect.self().onApply()
 

--- a/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
+++ b/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
@@ -211,7 +211,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
         self.fiducialPlacementToggle.setCurrentNode(self.segmentMarkupNode)
 
   def onSegmentModified(self, caller, event):
-    if not self.editButton.isEnabled() and self.segmentMarkupNode.GetNumberOfFiducials() != 0:
+    if not self.editButton.isEnabled() and self.segmentMarkupNode.GetNumberOfControlPoints() != 0:
       self.reset()
       # Create model node prior to markup node for display order
       self.createNewModelNode()
@@ -428,7 +428,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
       if slicer.app.majorVersion >= 5 or (slicer.app.majorVersion == 4 and slicer.app.minorVersion >= 11):
         count = self.segmentMarkupNode.GetNumberOfDefinedControlPoints()
       else:
-        count = self.segmentMarkupNode.GetNumberOfFiducials()
+        count = self.segmentMarkupNode.GetNumberOfControlPoints()
     return count
 
 class SurfaceCutLogic:
@@ -476,17 +476,16 @@ class SurfaceCutLogic:
     wasModified = segmentMarkupNode.StartModify()
     segmentMarkupNode.RemoveAllControlPoints()
     for i in range(fPosNum):
-      segmentMarkupNode.AddFiducialFromArray(fPos[i])
+      segmentMarkupNode.AddControlPoint(fPos[i])
     segmentMarkupNode.EndModify(wasModified)
 
   def getPointsAsString(self, segmentMarkupNode):
     # get fiducial positions as space-separated list
     import numpy
-    n = segmentMarkupNode.GetNumberOfFiducials()
+    n = segmentMarkupNode.GetNumberOfControlPoints()
     fPos = []
     for i in range(n):
-      coord = [0.0, 0.0, 0.0]
-      segmentMarkupNode.GetNthFiducialPosition(i, coord)
+      coord = segmentMarkupNode.GetNthControlPointPosition(i)
       fPos.extend(coord)
     fPosString = ' '.join(map(str, fPos))
     return fPosString


### PR DESCRIPTION
This PR makes updates to use non-deprecated Markups API when using latest Slicer version.