### PR TITLE
BUG: Fix leak of extra fiducial display nodes

### DIFF
--- a/SegmentEditorSurfaceCut/SegmentEditorSurfaceCut.py
+++ b/SegmentEditorSurfaceCut/SegmentEditorSurfaceCut.py
@@ -44,6 +44,7 @@ class SegmentEditorSurfaceCutTest(ScriptedLoadableModuleTest):
     """
     self.setUp()
     self.test_SurfaceCut1()
+    self.test_SurfaceCut2()
 
   def test_SurfaceCut1(self):
     """
@@ -154,3 +155,85 @@ class SegmentEditorSurfaceCutTest(ScriptedLoadableModuleTest):
     self.assertEqual( round(stats['Tumor', 'LabelmapSegmentStatisticsPlugin.volume_mm3']), 19498.0)
 
     self.delayDisplay('test_SurfaceCut1 passed')
+
+  def test_SurfaceCut2(self):
+    """
+    A test to confirm appropriate number of nodes created during use of the effect.
+    The test can be executed from SelfTests module (test name: SegmentEditorSurfaceCut)
+    """
+    self.delayDisplay("Starting test_SurfaceCut2")
+
+    ##################################
+    self.delayDisplay("Load source volume")
+
+    import SampleData
+    sourceVolumeNode = SampleData.SampleDataLogic().downloadMRHead()
+
+    ##################################
+    self.delayDisplay("Create segmentation")
+
+    segmentationNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
+    segmentationNode.CreateDefaultDisplayNodes()
+    segmentationNode.SetReferenceImageGeometryParameterFromVolumeNode(sourceVolumeNode)
+    segmentationNode.GetSegmentation().AddEmptySegment("FirstSegment")
+
+    ##################################
+    self.delayDisplay("Create segment editor")
+
+    segmentEditorWidget = slicer.qMRMLSegmentEditorWidget()
+    segmentEditorWidget.show()
+    segmentEditorWidget.setMRMLScene(slicer.mrmlScene)
+    segmentEditorNode = slicer.vtkMRMLSegmentEditorNode()
+    slicer.mrmlScene.AddNode(segmentEditorNode)
+    segmentEditorWidget.setMRMLSegmentEditorNode(segmentEditorNode)
+    segmentEditorWidget.setSegmentationNode(segmentationNode)
+    segmentEditorWidget.setSourceVolumeNode(sourceVolumeNode)
+
+    # Get the original fiducial display node count
+    segmentEditorWidget.setCurrentSegmentID("FirstSegment")
+    original_fiducial_display_node_count = slicer.mrmlScene.GetNumberOfNodesByClass("vtkMRMLMarkupsFiducialDisplayNode")
+    print(f"Number of fiducial display nodes after adding a segment: {original_fiducial_display_node_count}")
+
+    # Set active effect and compare display node count
+    segmentEditorWidget.setActiveEffectByName("Surface cut")
+    fiducial_display_node_count = slicer.mrmlScene.GetNumberOfNodesByClass("vtkMRMLMarkupsFiducialDisplayNode")
+    print(f"Number of fiducial display nodes after setting Surface Cut as active effect: {fiducial_display_node_count}")
+    self.assertEqual(fiducial_display_node_count, original_fiducial_display_node_count + 1)
+
+    # Add Surface cut points and apply. Then compare display node count
+    active_effect = segmentEditorWidget.activeEffect()
+    active_effect.self().fiducialPlacementToggle.placeButton().click()
+    red_slice = slicer.app.layoutManager().sliceWidget('Red')
+    height = red_slice.height
+    width = red_slice.width
+    point1 = [0 + width//2, 18 + height//2, -10]
+    point2 = [33 + width//2, -18 + height//2, -10]
+    point3 = [-33 + width//2, -18 + height//2, -10]
+    slicer.util.clickAndDrag(red_slice, start=point1, end=point1,button='Left')
+    slicer.util.clickAndDrag(red_slice, start=point2, end=point2,button='Left')
+    slicer.util.clickAndDrag(red_slice, start=point3, end=point3,button='Left')
+    active_effect.self().onApply()
+    fiducial_display_node_count = slicer.mrmlScene.GetNumberOfNodesByClass("vtkMRMLMarkupsFiducialDisplayNode")
+    print(f"Number of fiducial display nodes after applying the Surface Cut effect: {fiducial_display_node_count}")
+    self.assertEqual(fiducial_display_node_count, original_fiducial_display_node_count + 1)
+
+    # Add a second segment, add Surface cut points and apply. Then compare display node count
+    segmentationNode.GetSegmentation().AddEmptySegment("SecondSegment")
+    segmentEditorWidget.setCurrentSegmentID("SecondSegment")
+    active_effect.self().fiducialPlacementToggle.placeButton().click()
+    point1 = [0 + width//2, -50 + height//2, -10]
+    point2 = [33 + width//2, -90 + height//2, -10]
+    point3 = [-33 + width//2, -90 + height//2, -10]
+    slicer.util.clickAndDrag(red_slice, start=point1, end=point1,button='Left')
+    slicer.util.clickAndDrag(red_slice, start=point2, end=point2,button='Left')
+    slicer.util.clickAndDrag(red_slice, start=point3, end=point3,button='Left')
+    active_effect.self().onApply()
+    fiducial_display_node_count = slicer.mrmlScene.GetNumberOfNodesByClass("vtkMRMLMarkupsFiducialDisplayNode")
+    print(f"Number of fiducial display nodes after applying the Surface Cut effect for a 2nd segment: {fiducial_display_node_count}")
+    self.assertEqual(fiducial_display_node_count, original_fiducial_display_node_count + 1)
+
+    # Set active effect to None. Then compare display node count
+    segmentEditorWidget.setActiveEffectByName("None")
+    fiducial_display_node_count = slicer.mrmlScene.GetNumberOfNodesByClass("vtkMRMLMarkupsFiducialDisplayNode")
+    print(f"Number of fiducial display nodes after switching the active effect to None: {fiducial_display_node_count}")
+    self.assertEqual(fiducial_display_node_count, original_fiducial_display_node_count)

--- a/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
+++ b/SegmentEditorSurfaceCut/SegmentEditorSurfaceCutLib/SegmentEditorEffect.py
@@ -328,14 +328,15 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
   def createNewMarkupNode(self):
     # Create empty markup fiducial node
     if self.segmentMarkupNode is None:
-      displayNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsDisplayNode")
+      self.segmentMarkupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
+      self.segmentMarkupNode.SetSaveWithScene(False)  # prevent temporary node from being saved into the scene
+      self.segmentMarkupNode.CreateDefaultDisplayNodes()  # creates a display node if there is not one already for this node
+      displayNode = self.segmentMarkupNode.GetDisplayNode()
       displayNode.SetSaveWithScene(False)  # prevent temporary node from being saved into the scene
       displayNode.SetTextScale(0)
       # Need to disable snapping to visible surface, as it would result in the surface iteratively crawling
       # towards the camera as the point is moved.
       displayNode.SetSnapMode(displayNode.SnapModeUnconstrained)
-      self.segmentMarkupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")
-      self.segmentMarkupNode.SetSaveWithScene(False)  # prevent temporary node from being saved into the scene
       # Prevent "Edit properties..." from being displayed
       # (Edit properties would switch module, which would deactive the effect, thus remove the markups node
       # while the markups node's event is being processed, causing a crash)
@@ -348,7 +349,6 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
       pluginLogic.setAllowedViewContextMenuActionNamesForItem(itemId, ["DeletePointAction"])
 
       self.segmentMarkupNode.SetName('C')
-      self.segmentMarkupNode.SetAndObserveDisplayNodeID(displayNode.GetID())
       self.setAndObserveSegmentMarkupNode(self.segmentMarkupNode)
       self.updateGUIFromMRML()
 


### PR DESCRIPTION
Likely at some point when `segmentMarkupNode` began using `self.segmentMarkupNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsFiducialNode")`, there was an unintended 2 display nodes for the object as the AddNewNodeByClass creates a display node by default and the SegmentEffect code was also manually creating a display node and setting it to the FiducialNode.

I've added a TEST commit that can be run through SelfTests which detects this issue. Then my BUG fix results in the new tests passing.

cc: @lassoan 