### PR TITLE
ENH: Implement deactivate() for fast marching

### DIFF
--- a/SegmentEditorFastMarching/SegmentEditorFastMarchingLib/SegmentEditorEffect.py
+++ b/SegmentEditorFastMarching/SegmentEditorFastMarchingLib/SegmentEditorEffect.py
@@ -253,14 +253,19 @@ The effect uses <a href="http://www.spl.harvard.edu/publications/item/view/193">
     # If original segment is available then restore that
     if self.originalSelectedSegmentLabelmap:
       import vtkSegmentationCorePython as vtkSegmentationCore
+      modifierLabelmap = vtkSegmentationCore.vtkOrientedImageData()
+      modifierLabelmap.DeepCopy(self.originalSelectedSegmentLabelmap)
+      self.originalSelectedSegmentLabelmap = None
       segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
-      slicer.vtkSlicerSegmentationsModuleLogic.SetBinaryLabelmapToSegment(self.originalSelectedSegmentLabelmap, segmentationNode, self.selectedSegmentId, slicer.vtkSlicerSegmentationsModuleLogic.MODE_REPLACE, self.originalSelectedSegmentLabelmap.GetExtent())
+      slicer.vtkSlicerSegmentationsModuleLogic.SetBinaryLabelmapToSegment(modifierLabelmap, segmentationNode, self.selectedSegmentId, slicer.vtkSlicerSegmentationsModuleLogic.MODE_REPLACE, modifierLabelmap.GetExtent())
 
-    self.originalSelectedSegmentLabelmap = None
     self.selectedSegmentId = None
     self.fm = None
 
     self.updateGUIFromMRML()
+
+  def deactivate(self):
+    self.reset()
 
   def onCancel(self):
     self.reset()


### PR DESCRIPTION
This PR adds an implementation of `deactivate()` to the Fast Marching segment editor effect to address the issue where the "preview" label map was not cleaned up when the user switches to another segment editor effect or module. This presented some confusing possibilities, such as the one shown in the video below where a user could edit the preview label map.

## This PR 
https://github.com/user-attachments/assets/700fda1d-7bbb-4d22-8160-7b0b5b1b3ca8 

## Current `main` branch
https://github.com/user-attachments/assets/f3b694a3-a18c-4c19-9c32-191699b1cdea