### PR TITLE
ENH: Improve fast marching preview setup

### DIFF
--- a/SegmentEditorFastMarching/SegmentEditorFastMarchingLib/SegmentEditorEffect.py
+++ b/SegmentEditorFastMarching/SegmentEditorFastMarchingLib/SegmentEditorEffect.py
@@ -253,14 +253,19 @@ The effect uses <a href="http://www.spl.harvard.edu/publications/item/view/193">
     # If original segment is available then restore that
     if self.originalSelectedSegmentLabelmap:
       import vtkSegmentationCorePython as vtkSegmentationCore
+      modifierLabelmap = vtkSegmentationCore.vtkOrientedImageData()
+      modifierLabelmap.DeepCopy(self.originalSelectedSegmentLabelmap)
+      self.originalSelectedSegmentLabelmap = None
       segmentationNode = self.scriptedEffect.parameterSetNode().GetSegmentationNode()
-      slicer.vtkSlicerSegmentationsModuleLogic.SetBinaryLabelmapToSegment(self.originalSelectedSegmentLabelmap, segmentationNode, self.selectedSegmentId, slicer.vtkSlicerSegmentationsModuleLogic.MODE_REPLACE, self.originalSelectedSegmentLabelmap.GetExtent())
+      slicer.vtkSlicerSegmentationsModuleLogic.SetBinaryLabelmapToSegment(modifierLabelmap, segmentationNode, self.selectedSegmentId, slicer.vtkSlicerSegmentationsModuleLogic.MODE_REPLACE, modifierLabelmap.GetExtent())
 
-    self.originalSelectedSegmentLabelmap = None
     self.selectedSegmentId = None
     self.fm = None
 
     self.updateGUIFromMRML()
+
+  def deactivate(self):
+    self.reset()
 
   def onCancel(self):
     self.reset()


### PR DESCRIPTION
Should be rebased if https://github.com/lassoan/SlicerSegmentEditorExtraEffects/pull/63 is merged

This PR modifies the Fast Marching editor effect to store and display a segmentation preview in a new segmentation node, rather than overwriting the input segment with preview data. This has the benefit of not losing the original segment data in certain scenarios, eg, the user saving the scene and closing during the preview step. 

I am marking this PR as draft for the time being because I have a couple of questions:
1. Would it be preferable to have this effect inherit from `AbstractScriptedSegmentEditorAutoCompleteEffect`? I started down this path initially but found that it would require a bit more work than originally anticipated to get things working. The work in this PR was the path of least resistance.
2. Should the original segment be hidden during preview to maintain the look and feel of the Fast Marching effect in its current state?