### PR TITLE
BUG: Fix LT cursor lost on ROI creation

### DIFF
--- a/SegmentEditorLocalThreshold/SegmentEditorLocalThresholdLib/SegmentEditorEffect.py
+++ b/SegmentEditorLocalThreshold/SegmentEditorLocalThresholdLib/SegmentEditorEffect.py
@@ -203,6 +203,9 @@ Fill segment in a selected region based on source volume intensity range<br>.
 
     self.scriptedEffect.parameterSetNode().SetNodeReferenceID(self.ROI_NODE_REFERENCE_ROLE, self.roiSelector.currentNodeID)
 
+  # restore the effect-specific cursor in the case where the user has created a new ROI using the roiSelector combobox
+    slicer.modules.SegmentEditorWidget.editor.applySegmentEffectCursor(self.scriptedEffect)
+
   def processInteractionEvents(self, callerInteractor, eventId, viewWidget):
     abortEvent = False
 


### PR DESCRIPTION
The motivation for this PR is to address an issue affecting the local threshold tool which causes the effect-specific cursor to revert to the default arrow-pointer cursor when a user adds an ROI node from the tool's options panel. 

This PR depends on https://github.com/Slicer/Slicer/pull/8763